### PR TITLE
Clarify optional printed upgrades in package copy

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
                 "25 edited photos",
                 "Digital delivery",
                 "Advanced retouching",
-                "2 printed photos (5×7)",
+                "Optional add-on: 5×7 printed photos (on request, additional fee)",
               ]}
               featured={true}
               delay={100}
@@ -122,8 +122,8 @@ export default function Home() {
                 "35 edited photos",
                 "Digital delivery",
                 "Premium retouching",
-                "5 printed photos (5×7)",
-                "One 11×14 mounted print",
+                "Optional add-on: 5×7 printed photos (on request, additional fee)",
+                "Optional upgrade: 11×14 mounted print (on request, additional fee)",
               ]}
               delay={200}
             />


### PR DESCRIPTION
## Summary
- mark printed photos in the Deluxe package as an optional, on-request upgrade with an additional fee
- update the Premium package copy to note printed photos and mounted print are optional upgrades
- reviewed the packages section to confirm there is no remaining language implying printed products are included by default

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d01a6ef6dc8326b656d9d1d3d5f36b